### PR TITLE
Fix link to inserting divs section

### DIFF
--- a/syntax/markdown.md
+++ b/syntax/markdown.md
@@ -298,7 +298,7 @@ you get: some ~~~<span style="color:magenta;">coloured</span>~~~ text (note that
 
 You could also use this to locally customise a layout etc.
 
-\note{Inside a raw HTML block, you cannot use markdown, maths, etc. For this reason, it is often preferable to use nested `@@divname...@@` blocks instead of raw HTML since those _can_ have markdown, maths, etc. in them. (See [inserting divs](/syntax/divs-commands.html).)}
+\note{Inside a raw HTML block, you cannot use markdown, maths, etc. For this reason, it is often preferable to use nested `@@divname...@@` blocks instead of raw HTML since those _can_ have markdown, maths, etc. in them. (See [inserting divs](/syntax/divs-commands/).)}
 
 ## File insertions
 A few commands are defined to help you with insertions of content; you can also define your own commands using custom HTML as was discussed before.


### PR DESCRIPTION
In /syntax/markdown/, the link to "inserting divs" in "Raw HTML" section is wrong. I fix it.