### PR TITLE
Mentioning other ways of generating tables

### DIFF
--- a/syntax/markdown.md
+++ b/syntax/markdown.md
@@ -429,3 +429,13 @@ There's a couple of rules that you have to keep in mind when using the `\tablein
 * Columns must be separated by a comma (`,`).
 * If a header is specified, its length must match the number of columns in the file.
 @@
+
+The standard way of creating tables in Markdown, namely using:
+
+```markdown
+| Heading 1 | Heading 2 | Heading 3 |
+|-----------|-----------|-----------|
+| LaTeX     | KaTeX     | MikTeX    |
+```
+
+can also be used. It is also possible to use HTML to create a table with the HTML fenced between `~~~`. 


### PR DESCRIPTION
Hi folks,

I noticed an important omission in the documentation that I thought I'd remove. Namely, tables can also be created using Markdown and HTML. I'm not sure, but I'd guess that tables generated using CSV probably do not have support for KaTeX. But tables generated using Markdown do (I just tested that too), so this information may benefit some users. 

Thanks for your time.